### PR TITLE
Add sphinx doc generator configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ project(deeplog VERSION 0.0.0 LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake/")
 include(EnforceOutOfSourceBuilds)
+include(CMakeDependentOption)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
@@ -86,6 +87,12 @@ endif()
 find_package(Boost 1.73 REQUIRED COMPONENTS
     ${DLOG_REQUIRE_UNIT_TEST_FRAMEWORK}
 )
+
+find_package(sphinx)
+cmake_dependent_option(BUILD_DOCS "Build the documentation using sphinx." ON "SPHINX_FOUND" OFF)
+if (BUILD_DOCS)
+    add_subdirectory(docs)
+endif()
 
 ########################################################################
 # warning configuration

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,34 @@
+#[=====================================================================[
+
+Written in 2019, 2021 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to the
+public domain worldwide. This software is distributed without any warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication
+along with this software. If not, see
+
+    http://creativecommons.org/publicdomain/zero/1.0/
+
+#]=====================================================================]
+
+set(DOCS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs_out")
+
+add_custom_command(
+    OUTPUT "${DOCS_OUTPUT_DIR}/index.html"
+    COMMAND
+        "${SPHINX_EXECUTABLE}" -b html
+        "${CMAKE_CURRENT_LIST_DIR}" # sphinx input dir
+        "${DOCS_OUTPUT_DIR}"  # sphinx output dir
+
+    MAIN_DEPENDENCY "${CMAKE_CURRENT_LIST_DIR}/conf.py"
+    DEPENDS
+        "${CMAKE_CURRENT_LIST_DIR}/index.rst"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMENT "Compiling project documentation"
+)
+
+add_custom_target(docs ALL DEPENDS "${DOCS_OUTPUT_DIR}/index.html")
+
+install(DIRECTORY "${DOCS_OUTPUT_DIR}" TYPE DOC)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,61 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'deeplog'
+copyright = '2021, Henrik S. Gaßmann'
+author = 'Henrik S. Gaßmann'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+primary_domain = 'cpp'
+highlight_language = 'cpp'
+cpp_index_common_prefix = [
+    'dplx::dlog::',
+    'dplx::',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. deeplog documentation master file, created by
+   sphinx-quickstart on Mon Nov  8 14:19:08 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to deeplog's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/tools/cmake/Findsphinx.cmake
+++ b/tools/cmake/Findsphinx.cmake
@@ -1,0 +1,10 @@
+find_program(SPHINX_EXECUTABLE
+    NAMES sphinx-build
+    DOC "path to sphinx-build"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(sphinx
+    "Failed to find sphinx-build executable"
+    SPHINX_EXECUTABLE
+)


### PR DESCRIPTION

### Purpose
Add a documentation generator/project.

### Solution Sketch
Add a sphinx based documentation project and integrate it with the cmake build. The docs can be build with the `docs` target.

***

### Checklist
- [x] Tested on `x64-linux-clang-debug`
- [x] Tested on `x64-linux-gcc-debug`
- [x] Tested on `x64-windows-clang-debug`
- [x] Tested on `x64-windows-msvc-debug`
- [x] Tested on `x64-windows-msvc-lto`
- [x] `clang-format` is happy

Resolves #11