### PR TITLE
Cleanup error codings

### DIFF
--- a/sources.cmake
+++ b/sources.cmake
@@ -7,7 +7,6 @@ dplx_target_sources(deeplog
     PUBLIC
         dlog
 
-        dlog/disappointment
         dlog/definitions
 
         dlog/core
@@ -23,6 +22,15 @@ dplx_target_sources(deeplog
         dlog/file_database
 
         dlog/detail/interleaving_stream
+)
+
+dplx_target_sources(deeplog
+    TEST_TARGET deeplog-tests
+    MODE SMART_HEADER_ONLY MERGED_LAYOUT
+    BASE_DIR dplx
+
+    PUBLIC
+        dlog/disappointment
 )
 
 dplx_target_sources(deeplog

--- a/src/dplx/dlog/argument_transmorpher_fmt.hpp
+++ b/src/dplx/dlog/argument_transmorpher_fmt.hpp
@@ -105,7 +105,7 @@ public:
         }
         catch (std::bad_alloc const &)
         {
-            return system_error::errc::not_enough_memory;
+            return errc::not_enough_memory;
         }
     }
 

--- a/src/dplx/dlog/argument_transmorpher_fmt.hpp
+++ b/src/dplx/dlog/argument_transmorpher_fmt.hpp
@@ -161,7 +161,7 @@ private:
             return revive(ctx, store, name);
         }
 
-        return errc::bad; // TODO: proper error code for unknown arg type id
+        return errc::unknown_argument_type_id;
     }
 
     template <typename T>

--- a/src/dplx/dlog/attribute_transmorpher.hpp
+++ b/src/dplx/dlog/attribute_transmorpher.hpp
@@ -260,7 +260,7 @@ private:
             return dp::oc::success();
         }
 
-        return dp::errc::bad;
+        return errc::unknown_attribute_type_id;
     }
 
     template <typename ReType>

--- a/src/dplx/dlog/attribute_transmorpher.hpp
+++ b/src/dplx/dlog/attribute_transmorpher.hpp
@@ -66,7 +66,7 @@ public:
             }
             catch (std::bad_alloc const &)
             {
-                return system_error::errc::not_enough_memory;
+                return errc::not_enough_memory;
             }
         }
         return mStringified;
@@ -227,7 +227,7 @@ public:
         }
         catch (std::bad_alloc const &)
         {
-            return system_error::errc::not_enough_memory;
+            return errc::not_enough_memory;
         }
     }
 
@@ -254,7 +254,7 @@ private:
             }
             catch (std::bad_alloc const &)
             {
-                return system_error::errc::not_enough_memory;
+                return errc::not_enough_memory;
             }
 
             return dp::oc::success();
@@ -284,7 +284,7 @@ private:
         }
         catch (std::bad_alloc const &)
         {
-            return system_error::errc::not_enough_memory;
+            return errc::not_enough_memory;
         }
     }
 };

--- a/src/dplx/dlog/bus/mpsc_bus.cpp
+++ b/src/dplx/dlog/bus/mpsc_bus.cpp
@@ -131,20 +131,20 @@ auto mpsc_bus_handle::mpsc_bus(llfio::mapped_file_handle &&backingFile,
     constexpr std::size_t page_size = std::size_t{4U} * 1024U;
     if (std::numeric_limits<std::uint32_t>::max() - page_size < regionSize)
     {
-        return errc::out_of_memory;
+        return errc::invalid_argument;
     }
     std::size_t const realRegionSize = cncr::round_up_p2(regionSize, page_size);
 
     std::size_t const combinedRegionSize = numRegions * realRegionSize;
     if (combinedRegionSize / realRegionSize != numRegions)
     {
-        return errc::out_of_memory;
+        return errc::invalid_argument;
     }
 
     std::size_t const fileSize = combinedRegionSize + head_area_size;
     if (fileSize < combinedRegionSize || !std::in_range<extent_type>(fileSize))
     {
-        return errc::out_of_memory;
+        return errc::invalid_argument;
     }
 
     llfio::unique_file_lock fileLock(backingFile, llfio::lock_kind::unlocked);

--- a/src/dplx/dlog/detail/file_stream.hpp
+++ b/src/dplx/dlog/detail/file_stream.hpp
@@ -95,7 +95,7 @@ private:
     {
         if (!dataSource.is_readable() || !dataSource.is_seekable())
         {
-            return system_error::errc::invalid_seek;
+            return errc::invalid_argument;
         }
 
         DPLX_TRY(pages.resize(buffer_size));

--- a/src/dplx/dlog/disappointment.cpp
+++ b/src/dplx/dlog/disappointment.cpp
@@ -1,8 +1,0 @@
-
-#include <outcome/experimental/status_result.hpp>
-#include <outcome/try.hpp>
-#include <status-code/system_code.hpp>
-
-#include <dplx/cncr/data_defined_status_domain.hpp>
-//
-#include <llfio/llfio.hpp>

--- a/src/dplx/dlog/disappointment.hpp
+++ b/src/dplx/dlog/disappointment.hpp
@@ -38,7 +38,6 @@ namespace oc = OUTCOME_V2_NAMESPACE;
 
 enum class errc
 {
-    nothing = 0, // to be removed
     bad = 1,
     invalid_argument,
     not_enough_memory,
@@ -67,8 +66,6 @@ struct dplx::cncr::status_enum_definition<::dplx::dlog::errc>
 
     static constexpr value_descriptor values[] = {
   // clang-format off
-        { code::nothing, generic_errc::success,
-            "no error/success" },
         { code::bad, generic_errc::unknown,
             "an external API did not meet its operation contract"},
         { code::invalid_argument, generic_errc::invalid_argument,

--- a/src/dplx/dlog/disappointment.hpp
+++ b/src/dplx/dlog/disappointment.hpp
@@ -41,7 +41,7 @@ enum class errc
     nothing = 0, // to be removed
     bad = 1,
     invalid_argument,
-    out_of_memory,
+    not_enough_memory,
     not_enough_space,
     missing_data,
     invalid_file_database_header,
@@ -73,7 +73,7 @@ struct dplx::cncr::status_enum_definition<::dplx::dlog::errc>
             "an external API did not meet its operation contract"},
         { code::invalid_argument, generic_errc::invalid_argument,
             "Invalid Argument" },
-        { code::out_of_memory, generic_errc::not_enough_memory,
+        { code::not_enough_memory, generic_errc::not_enough_memory,
             "The operation did not succeed due to a memory allocation failure" },
         { code::not_enough_space, generic_errc::no_buffer_space,
             "The operation failed to allocate a write buffer of sufficient size" },

--- a/src/dplx/dlog/disappointment.hpp
+++ b/src/dplx/dlog/disappointment.hpp
@@ -45,6 +45,7 @@ enum class errc
     missing_data,
     invalid_file_database_header,
     invalid_record_container_header,
+    container_unlink_failed,
 
     LIMIT,
 };
@@ -80,6 +81,8 @@ struct dplx::cncr::status_enum_definition<::dplx::dlog::errc>
             "The .drot file doesn't start with a valid header" },
         { code::invalid_record_container_header, generic_errc::unknown,
             "The .dlog file doesn't start with a valid header" },
+        { code::container_unlink_failed, generic_errc::unknown,
+            "Failed to unlink one or more of the referenced record container(s)" },
   // clang-format on
     };
 };

--- a/src/dplx/dlog/disappointment.hpp
+++ b/src/dplx/dlog/disappointment.hpp
@@ -1,5 +1,5 @@
 
-// Copyright Henrik Steffen Gaßmann 2021
+// Copyright Henrik Steffen Gaßmann 2021-2023
 //
 // Distributed under the Boost Software License, Version 1.0.
 //         (See accompanying file LICENSE or copy at
@@ -71,11 +71,20 @@ struct dplx::cncr::status_enum_definition<::dplx::dlog::errc>
             "no error/success" },
         { code::bad, generic_errc::unknown,
             "an external API did not meet its operation contract"},
+        { code::invalid_argument, generic_errc::invalid_argument,
+            "Invalid Argument" },
+        { code::out_of_memory, generic_errc::not_enough_memory,
+            "The operation did not succeed due to a memory allocation failure" },
+        { code::not_enough_space, generic_errc::no_buffer_space,
+            "The operation failed to allocate a write buffer of sufficient size" },
+        { code::missing_data, generic_errc::unknown,
+            "The file/message is missing data at its end" },
+        { code::invalid_file_database_header, generic_errc::unknown,
+            "The .drot file doesn't start with a valid header" },
+        { code::invalid_record_container_header, generic_errc::unknown,
+            "The .dlog file doesn't start with a valid header" },
   // clang-format on
     };
-
-    // static_assert(std::size(values) ==
-    // static_cast<std::size_t>(code::LIMIT));
 };
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)

--- a/src/dplx/dlog/disappointment.hpp
+++ b/src/dplx/dlog/disappointment.hpp
@@ -46,6 +46,8 @@ enum class errc
     invalid_file_database_header,
     invalid_record_container_header,
     container_unlink_failed,
+    unknown_argument_type_id,
+    unknown_attribute_type_id,
 
     LIMIT,
 };
@@ -83,6 +85,10 @@ struct dplx::cncr::status_enum_definition<::dplx::dlog::errc>
             "The .dlog file doesn't start with a valid header" },
         { code::container_unlink_failed, generic_errc::unknown,
             "Failed to unlink one or more of the referenced record container(s)" },
+        { code::unknown_argument_type_id, generic_errc::unknown,
+            "Could not decode the serialized argument due to an unknown type_id" },
+        { code::unknown_attribute_type_id, generic_errc::unknown,
+            "Could not decode the serialized attribute due to an unknown type_id" },
   // clang-format on
     };
 };

--- a/src/dplx/dlog/disappointment.test.cpp
+++ b/src/dplx/dlog/disappointment.test.cpp
@@ -13,7 +13,7 @@ namespace dlog_tests
 {
 
 static_assert(std::size(dplx::cncr::status_enum_definition<dlog::errc>::values)
-              == static_cast<std::size_t>(dlog::errc::LIMIT));
+              == static_cast<std::size_t>(dlog::errc::LIMIT) - 1U);
 static_assert(dplx::cncr::validate_status_enum_definition_data<dlog::errc>());
 
 } // namespace dlog_tests

--- a/src/dplx/dlog/disappointment.test.cpp
+++ b/src/dplx/dlog/disappointment.test.cpp
@@ -6,3 +6,14 @@
 //           https://www.boost.org/LICENSE_1_0.txt)
 
 #include "dplx/dlog/disappointment.hpp"
+
+#include "test_utils.hpp"
+
+namespace dlog_tests
+{
+
+static_assert(std::size(dplx::cncr::status_enum_definition<dlog::errc>::values)
+              == static_cast<std::size_t>(dlog::errc::LIMIT));
+static_assert(dplx::cncr::validate_status_enum_definition_data<dlog::errc>());
+
+} // namespace dlog_tests

--- a/src/dplx/dlog/file_database.cpp
+++ b/src/dplx/dlog/file_database.cpp
@@ -121,7 +121,7 @@ auto file_database_handle::unlink_all() noexcept -> result<void>
 
     if (!mContents.record_containers.empty())
     {
-        return system_error::errc::directory_not_empty;
+        return errc::container_unlink_failed;
     }
 
     rootLock.unlock();


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
Finish the migration to SG14 status-code and cleanup error handling code smells. 

Resolves #6

### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
* Add proper error code descriptors for all existing error codes. 
* Replace improper usage of `errc::bad` with (new) specific error codes.
* Don't return `system_error2::errc` anywhere.