### PR TITLE
refactor!: Align severity values with OTLP

### DIFF
--- a/src/dplx/dlog/definitions.cpp
+++ b/src/dplx/dlog/definitions.cpp
@@ -39,14 +39,13 @@ auto dplx::dp::codec<dplx::dlog::severity>::decode(
         -> result<void>
 {
     underlying_type underlyingValue; // NOLINT(cppcoreguidelines-init-variables)
-    if (result<void> parseRx = dp::parse_integer<underlying_type>(
-                ctx, underlyingValue,
-                cncr::to_underlying(dlog::severity::trace));
+    if (result<void> parseRx
+        = dp::parse_integer<underlying_type>(ctx, underlyingValue, encoded_max);
         parseRx.has_failure())
     {
         return static_cast<result<void> &&>(parseRx).as_failure();
     }
-    outValue = static_cast<dlog::severity>(underlyingValue);
+    outValue = static_cast<dlog::severity>(underlyingValue + encoding_offset);
     return oc::success();
 }
 

--- a/src/dplx/dlog/definitions.hpp
+++ b/src/dplx/dlog/definitions.hpp
@@ -73,12 +73,12 @@ namespace dplx::dlog
 enum class severity : unsigned
 {
     none = 0,
-    critical = 1,
-    error = 2,
-    warn = 3,
-    info = 4,
+    trace = 1,
     debug = 5,
-    trace = 6,
+    info = 9,
+    warn = 13,
+    error = 17,
+    fatal = 21,
 };
 
 inline constexpr severity default_threshold = severity::warn;
@@ -89,6 +89,8 @@ template <>
 class dplx::dp::codec<dplx::dlog::severity>
 {
     using underlying_type = std::underlying_type_t<dlog::severity>;
+    static inline constexpr underlying_type encoded_max = 23;
+    static inline constexpr underlying_type encoding_offset = 1;
 
 public:
     static constexpr auto size_of(emit_context &, dplx::dlog::severity) noexcept

--- a/src/dplx/dlog/macros.hpp
+++ b/src/dplx/dlog/macros.hpp
@@ -53,7 +53,7 @@
         if (auto &&_dlog_materialized_temporary_                               \
             = (::dplx::dlog::detail::active_span);                             \
             _dlog_materialized_temporary_ != nullptr                           \
-            && _dlog_materialized_temporary_->threshold >= (severity))         \
+            && (severity) >= _dlog_materialized_temporary_->threshold)         \
             (void)::dplx::dlog::log(*_dlog_materialized_temporary_,            \
                                     (severity), (message), DPLX_DLOG_LOCATION, \
                                     __VA_ARGS__);                              \
@@ -63,7 +63,7 @@
     do                                                                         \
     { /* due to shadowing this name isn't required to be unique */             \
         if (auto &&_dlog_materialized_temporary_ = (ctx);                      \
-            _dlog_materialized_temporary_.threshold >= (severity))             \
+            (severity) >= _dlog_materialized_temporary_.threshold)             \
             (void)::dplx::dlog::log(_dlog_materialized_temporary_, (severity), \
                                     (message), DPLX_DLOG_LOCATION,             \
                                     __VA_ARGS__);                              \
@@ -78,7 +78,7 @@
         if (auto &&_dlog_materialized_temporary_                               \
             = (::dplx::dlog::detail::active_span);                             \
             _dlog_materialized_temporary_ != nullptr                           \
-            && _dlog_materialized_temporary_->threshold >= (severity))         \
+            && (severity) >= _dlog_materialized_temporary_->threshold)         \
             (void)::dplx::dlog::log(                                           \
                     *_dlog_materialized_temporary_, (severity), (message),     \
                     DPLX_DLOG_LOCATION __VA_OPT__(, __VA_ARGS__));             \
@@ -88,7 +88,7 @@
     do                                                                         \
     { /* due to shadowing this name isn't required to be unique */             \
         if (auto &&_dlog_materialized_temporary_ = (ctx);                      \
-            _dlog_materialized_temporary_.threshold >= (severity))             \
+            (severity) >= _dlog_materialized_temporary_.threshold)             \
             (void)::dplx::dlog::log(                                           \
                     _dlog_materialized_temporary_, (severity), (message),      \
                     DPLX_DLOG_LOCATION __VA_OPT__(, __VA_ARGS__));             \

--- a/src/dplx/dlog/sink.cpp
+++ b/src/dplx/dlog/sink.cpp
@@ -26,7 +26,7 @@ struct copy_message_fn
     inline auto operator()(serialized_record_info const &message) const
             -> dp::result<void>
     {
-        if (message.message_severity < threshold)
+        if (message.message_severity >= threshold)
         {
             return out.bulk_write(message.raw_data);
         }


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
Resolves #23

### Solution Sketch
Use severity values specified by the OpenTelemetry standard. Note that this reverses the severity order.

Compress the severity value range from 1-24 to 0-23 for CBOR encoding in order to utilize the size efficient inline encoding.

