### PR TITLE
refactor!: Integrate applicable types with `dplx::make`

### DIFF
--- a/apps/deeplog-cli/deeplog.main.cpp
+++ b/apps/deeplog-cli/deeplog.main.cpp
@@ -112,12 +112,12 @@ private:
         }
 
         mFileSelection->DetachAllChildren();
-        for (auto &sink : resourcesView)
+        for (auto &sinkView : resourcesView)
         {
-            auto name = fmt::format("sink {}", sink.first);
+            auto name = fmt::format("sink {}", sinkView.first);
             mFileSelection->Add(ftxui::Renderer(
-                    sink.second,
-                    [name = std::move(name), component = sink.second] {
+                    sinkView.second,
+                    [name = std::move(name), component = sinkView.second] {
                         return ftxui::window(ftxui::text(name),
                                              component->Render());
                     }));

--- a/examples/log-complete/log-complete.main.cpp
+++ b/examples/log-complete/log-complete.main.cpp
@@ -36,15 +36,16 @@ inline auto main() -> result<void>
                                 baseDir, "log-test.drot"));
 
     constexpr auto regionSize = 1 << 14;
-    DPLX_TRY(auto &&mpscBus,
-             dlog::db_mpsc_bus_handle::create({
+    DPLX_TRY(mpsc_log_fabric &&core, (make<mpsc_log_fabric>{
+            .make_bus = {
                      .database = db,
                      .bus_id = "std"s,
                      .file_name_pattern = "{id}.{now:%FT%H-%M-%S}.dmpscb",
                      .num_regions = 4U,
                      .region_size = regionSize,
-             }));
-    mpsc_log_fabric core{std::move(mpscBus), dlog::severity::debug};
+             },
+            .default_threshold = dlog::severity::debug,
+            })());
 
     constexpr auto bufferSize = 64 * 1024;
     DPLX_TRY(auto *sink,

--- a/libs/deeplog/src/dplx/dlog/bus/buffer_bus.hpp
+++ b/libs/deeplog/src/dplx/dlog/bus/buffer_bus.hpp
@@ -16,6 +16,7 @@
 #include <dplx/dp/items/parse_core.hpp>
 #include <dplx/dp/streams/memory_input_stream.hpp>
 #include <dplx/dp/streams/memory_output_stream.hpp>
+#include <dplx/make.hpp>
 
 #include <dplx/dlog/concepts.hpp>
 #include <dplx/dlog/disappointment.hpp>
@@ -203,3 +204,16 @@ inline auto bufferbus(llfio::mapped_file_handle &&backingFile,
 }
 
 } // namespace dplx::dlog
+
+template <>
+struct dplx::make<dplx::dlog::bufferbus_handle>
+{
+    dlog::llfio::path_handle const &base;
+    dlog::llfio::path_view path;
+    unsigned int buffer_size;
+
+    auto operator()() const noexcept -> result<dlog::bufferbus_handle>
+    {
+        return dlog::bufferbus_handle::bufferbus(base, path, buffer_size);
+    }
+};

--- a/libs/deeplog/src/dplx/dlog/bus/mpsc_bus.test.cpp
+++ b/libs/deeplog/src/dplx/dlog/bus/mpsc_bus.test.cpp
@@ -32,6 +32,7 @@ namespace dlog_tests
 {
 
 static_assert(dlog::bus<dlog::mpsc_bus_handle>);
+static_assert(dlog::bus<dlog::db_mpsc_bus_handle>);
 
 TEST_CASE("mpsc_bus() creates a mpsc_bus_handle given a mapped_file_handle")
 {

--- a/libs/deeplog/src/dplx/dlog/concepts.hpp
+++ b/libs/deeplog/src/dplx/dlog/concepts.hpp
@@ -12,6 +12,7 @@
 #include <span>
 #include <string_view>
 
+#include <dplx/dp/fwd.hpp>
 #include <dplx/make.hpp>
 
 #include <dplx/dlog/fwd.hpp>
@@ -64,5 +65,14 @@ concept raw_message_consumer
                   static_cast<Fn &&>(fn)(msgs)
               } noexcept;
           };
+
+template <typename T>
+concept sink_backend = makable<T> && std::derived_from<T, dp::output_buffer>;
+
+template <typename T>
+concept sink = makable<T> && std::derived_from<T, sink_frontend_base>;
+
+template <sink_backend Backend>
+class basic_sink_frontend;
 
 } // namespace dplx::dlog

--- a/libs/deeplog/src/dplx/dlog/concepts.hpp
+++ b/libs/deeplog/src/dplx/dlog/concepts.hpp
@@ -12,6 +12,8 @@
 #include <span>
 #include <string_view>
 
+#include <dplx/make.hpp>
+
 #include <dplx/dlog/fwd.hpp>
 
 namespace dplx::dlog
@@ -23,7 +25,8 @@ using writable_bytes = std::span<std::byte>;
 // clang-format off
 template <typename T>
 concept bus
-        = requires(T instance,
+        = makable<T>
+       && requires(T instance,
                    record_output_buffer_storage &bufferPlacementStorage,
                    std::size_t const messageSize,
                    span_id const spanId,
@@ -36,6 +39,9 @@ concept bus
                     -> cncr::tryable;
         };
 // clang-format on
+
+template <bus MessageBus>
+class log_fabric;
 
 // clang-format off
 template <typename T>

--- a/libs/deeplog/src/dplx/dlog/fwd.hpp
+++ b/libs/deeplog/src/dplx/dlog/fwd.hpp
@@ -35,6 +35,8 @@ struct record_output_buffer_storage;
 class file_database_handle;
 
 class sink_frontend_base;
+class file_sink_backend;
+class file_sink_db_backend;
 
 class mpsc_bus_handle;
 class db_mpsc_bus_handle;

--- a/libs/deeplog/src/dplx/dlog/fwd.hpp
+++ b/libs/deeplog/src/dplx/dlog/fwd.hpp
@@ -36,6 +36,9 @@ class file_database_handle;
 
 class sink_frontend_base;
 
+class mpsc_bus_handle;
+class db_mpsc_bus_handle;
+
 namespace detail
 {
 

--- a/libs/deeplog/src/dplx/dlog/log_fabric.cpp
+++ b/libs/deeplog/src/dplx/dlog/log_fabric.cpp
@@ -18,21 +18,21 @@ void log_fabric_base::sync_sinks() noexcept
                    [](auto &sink) { return sink->try_sync(); });
 }
 
-auto log_fabric_base::attach_sink(std::unique_ptr<sink_frontend_base> &&sink)
+auto log_fabric_base::attach_sink(std::unique_ptr<sink_frontend_base> &&sinkPtr)
         -> sink_frontend_base *
 {
-    auto *const ptr = sink.get();
-    mSinks.push_back(std::move(sink));
+    auto *const ptr = sinkPtr.get();
+    mSinks.push_back(std::move(sinkPtr));
     return ptr;
 }
 
-auto log_fabric_base::attach_sink(std::unique_ptr<sink_frontend_base> &&sink,
+auto log_fabric_base::attach_sink(std::unique_ptr<sink_frontend_base> &&sinkPtr,
                                   std::nothrow_t) noexcept
         -> result<sink_frontend_base *>
 try
 {
-    auto *const ptr = sink.get();
-    mSinks.push_back(std::move(sink));
+    auto *const ptr = sinkPtr.get();
+    mSinks.push_back(std::move(sinkPtr));
     return ptr;
 }
 catch (std::bad_alloc const &)

--- a/libs/deeplog/src/dplx/dlog/log_fabric.test.cpp
+++ b/libs/deeplog/src/dplx/dlog/log_fabric.test.cpp
@@ -1,0 +1,19 @@
+
+// Copyright Henrik Steffen Gaßmann 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dlog/log_fabric.hpp"
+
+#include <dplx/dlog/bus/mpsc_bus.hpp>
+
+#include "test_utils.hpp"
+
+namespace dlog_tests
+{
+
+static_assert(makable<dlog::log_fabric<dlog::mpsc_bus_handle>>);
+
+}


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->
Instead of using ad-hoc factory patterns implement support for `dplx::make` which is also composable by default, e.g. it supports nesting factories in case of sink-frontends and -backends.
